### PR TITLE
Add support for 32-bit unsigned integer

### DIFF
--- a/define_types.pas
+++ b/define_types.pas
@@ -118,6 +118,8 @@ function PadStr (lValIn, lPadLenIn: integer): string;
 function ChangeFileExtX( lFilename: string; lExt: string): string;
 function swap4r4i (s:single): longint; //swap and convert: endian-swap and then typecast 32-bit float as 32-bit integer
 function conv4r4i (s:single): longint; //convert: typecast 32-bit float as 32-bit integer
+function swap4r4u (s:single): longword; //swap and convert: endian-swap and then typecast 32-bit float as 32-bit unsigned integer
+function conv4r4u (s:single): longword; //convert: typecast 32-bit float as 32-bit unsigned integer
 function swap8r(s : double):double; //endian-swap 64-bit float
 procedure pswap4i(var s : LongInt); //procedure to endian-swap 32-bit integer
 procedure pswap4r ( var s:single);  //procedure to endian-swap 32-bit integer
@@ -1143,6 +1145,38 @@ begin
   outguy.Word2 := swap(inguy^.Word1);
   swap4r4i:=outguy.long;
 end;//swap4r4i
+
+function conv4r4u (s:single): longword;
+type
+  swaptype = packed record
+    case byte of
+      1:(long:longword);
+  end;
+  swaptypep = ^swaptype;
+var
+  inguy:swaptypep;
+begin
+  inguy := @s; //assign address of s to inguy
+  conv4r4u:=inguy^.long;
+end;
+
+function swap4r4u (s:single): longword;
+type
+  swaptype = packed record
+    case byte of
+      0:(Word1,Word2 : word); //word is 16 bit
+      1:(long:longword);
+  end;
+  swaptypep = ^swaptype;
+var
+  inguy:swaptypep;
+  outguy:swaptype;
+begin
+  inguy := @s; //assign address of s to inguy
+  outguy.Word1 := swap(inguy^.Word2);
+  outguy.Word2 := swap(inguy^.Word1);
+  swap4r4u:=outguy.long;
+end;//swap4r4u
 
 (*function ChangeFileExtX( var lFilename: string; lExt: string): string;
 begin

--- a/nii_reslice.pas
+++ b/nii_reslice.pas
@@ -10,6 +10,7 @@ uses
 procedure NIFTIhdr_UnswapImg (var lHdr: TMRIcroHdr; var lImgBuffer: byteP); //ensures image data is in native space
 procedure NIFTIhdr_MinMaxImg (var lHdr: TMRIcroHdr; var lImgBuffer: byteP); //ensures image data is in native space
 procedure Int32ToFloat (var lHdr: TMRIcroHdr; var lImgBuffer: byteP);
+procedure Uint32ToFloat (var lHdr: TMRIcroHdr; var lImgBuffer: byteP);
 procedure Float32RemoveNAN (var lHdr: TMRIcroHdr; var lImgBuffer: byteP);
 
 function Reslice2Targ (lSrcName: string; var lTargHdr: TNIFTIHdr; var lDestHdr: TMRIcroHdr; lTrilinearInterpolation: boolean; lVolume: integer): string;
@@ -325,6 +326,25 @@ begin
     lHdr.NIFTIHdr.datatype := kDT_FLOAT;
     lHdr.DiskDataNativeEndian := true;
 end;//Int32ToFloat
+
+procedure Uint32ToFloat (var lHdr: TMRIcroHdr; var lImgBuffer: byteP);
+var
+  lI,lInVox: integer;
+  l32Buf : SingleP;
+begin
+    if lHdr.NIFTIHdr.datatype <> kDT_UINT32 then
+      exit;
+    lInVox :=  lHdr.NIFTIhdr.dim[1] *  lHdr.NIFTIhdr.dim[2] * lHdr.NIFTIhdr.dim[3];
+    l32Buf := SingleP(lImgBuffer );
+    if not lHdr.DiskDataNativeEndian then
+        for lI := 1 to lInVox do
+          l32Buf^[lI] := (Swap4r4u(l32Buf^[lI]))
+    else  //convert integer to float
+       for lI := 1 to lInVox do
+        l32Buf^[lI] := Conv4r4u(l32Buf^[lI]);
+    lHdr.NIFTIHdr.datatype := kDT_FLOAT;
+    lHdr.DiskDataNativeEndian := true;
+end;//Uint32ToFloat
 
 procedure Float32RemoveNAN (var lHdr: TMRIcroHdr; var lImgBuffer: byteP);
 //set "Not-A-Number" values to be zero... SPM uses NaN for voxels it can not compute

--- a/texture_3d_unit.pas
+++ b/texture_3d_unit.pas
@@ -1133,6 +1133,7 @@ begin //Proc Load_From_NIfTI
     end else
         lTexture.LabelRA := nil;
     Int32ToFloat(lHdr,lImgBuffer);
+    Uint32ToFloat(lHdr,lImgBuffer);
     Uint16ToFloat32(lHdr,lImgBuffer);
     Float64ToFloat32(lHdr,lImgBuffer);
     NIFTIhdr_UnswapImg (lHdr,lImgBuffer); //ensures image data is in native byteorder


### PR DESCRIPTION
This is handled exactly the same as for 32-bit signed integer files, converting
data to float.

This makes MRIcroGL in par with MacOS native version that supports uint32. The reason for that patch is making my colleagues using Linux be able to open uint32 volumetric data on Linux, same as I am able now using MRIcro on MacOS.
